### PR TITLE
childrenの型定義

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterworks/miffy-ui",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@counterworks/miffy-ui",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "module": "./lib/index.js",

--- a/src/components/Button/OutlineButton.tsx
+++ b/src/components/Button/OutlineButton.tsx
@@ -1,4 +1,4 @@
-import { FC, MouseEventHandler } from 'react';
+import { FC, MouseEventHandler, ReactNode } from 'react';
 import clsx from 'clsx';
 
 export const OutlineButton: FC<{
@@ -10,6 +10,7 @@ export const OutlineButton: FC<{
   type?: 'button' | 'submit';
   onClick?: MouseEventHandler<HTMLButtonElement>;
   disabled?: boolean;
+  children: ReactNode;
 }> = ({ color, className, onClick, children, type = 'button', size = 'auto', disabled = false, form = false, ...props }) => (
   <button
     className={clsx(


### PR DESCRIPTION
Reactのバージョンを上げたためchildrenの型定義の型を定義する必要があり修正
Buttonコンポーネントの方はすでにできていた